### PR TITLE
Formatting, rewording, split one article

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,110 @@
-# EOS Platform User Agreement
-## CHAIN ID == aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906
+# EOS User Agreement
 
-### Foreward
-This document was written by EOS New York for the benefit of the community and is a result of our participation in the community-driven development of EOS governance over the past year. In order to be more sensitive to the many different ways the word "constitution" can be perceived across cultures and languages we have shifted the title of this document to the EOS Platform User Agreement. This document is an open-source template and EOS New York will not directly submit it for referendum. It is up to the community to decide if they believe this Agreement is a good foundation on which to build the ways we make collective decisions and direct the growth of the EOS Mainnet. In short, you should feel empowered to take this document and change it, amend it, propose it, or otherwise mold it to fit what you believe is best.
+## CHAIN ID: aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906
+
+### Foreword
+
+This document was written by EOS New York for the benefit of the community and is a result of our participation in the community-driven development of EOS governance over the past year. In order to be more sensitive to the many different ways the word "constitution" can be perceived across cultures and languages we have shifted the title of this document to the EOS User Agreement (EOS-UA). This document is an open-source template and EOS New York will not directly submit it for referendum. It is up to the community to decide if they believe this Agreement is a good foundation on which to build the ways we make collective decisions and direct the growth of the EOS Mainnet. In short, you should feel empowered to take this document and change it, amend it, propose it, or otherwise mold it to fit what you believe is best.
 
 The design principles for this document:
+
 * Absolutely no items that are unenforceable.
 * Establishes a framework of "governing documents" so that amendment of the EOS governance can be agile across multiple documents rather than consolidated into one.
 * Defines roles and responsibilities of various user types.
 * Establishes the foundation of a dispute resolution framework and empowers individuals to self govern disputes as much as possible.
 
-### Article I - Process for ratification of this EOS Platform User Agreement.
-This user agreement is considered ratified and approved for purposes of governing EOS Blockchain {{chain_id}} when no less than 15% of issued tokens participating and no fewer than 10% more Yes than No votes, sustained for 30 continuous days within a 120 day period.
-### Article II - Defines the distributed jurisdiction of the EOS blockchain and that it exists in no physical place.
-The EOS blockchain {{chain_id}} is immutable and all records and actions are recorded forever. EOS blockchain {{chain_id}} exists in a distributed and decentralized jurisdiction. The EOS blockchain {{chain_id}} is to be governed by and construed under the rules contained herein, this duly ratified agreement.
-### Article III - Defines the User types and consent to the EOS Platform User Agreement.
-A User is any person or organization of persons who maintain(s) direct or indirect ownership of an EOS account, or property connected to an EOS account.
-* Users who sign regproducer agree to, and are bound by, the regproducer Ricardian Contract.
-* Users who sign regarb agree to, and are bound by, the regarb Ricardian Contract.
-* Users who sign regforum agree to, and are bound by, the regforum Ricardian Contract.
-### Article IV - Defines consent of this EOS Platform User Agreement.
-By claiming direct or indirect ownership of an EOS account or property connected to an EOS account on EOS blockchain {{chain_id}} Users consent to these terms, definitions, and agreed upon standards with full consideration between all Users. {{chain_id}} string is included in the signature of every transaction validated and included in a block and appended to the blockchain.
-### Article V - Outlines maintenance of all governing documents.
-The EOS Platform User Agreement, regproducer, regarb, regforum, are considered governing documents and are to be modified only by User referendum.
-### Article VI - Defines User Referendum.
-User referendum is the sole mechanism for altering governing documents and/or effecting network funds. User referendums must be submitted on-chain either in full text or as a hash of the referendum text. A User referendum is considered approved for execution once at least 15% of issued tokens have registered a vote for the associated referendum, ‘affirmative’ tokens exceed the number of ‘negative’ staked tokens by a difference of no less than 10% of total percentage of registered votes (i.e. 55% yes, 45% no) EOS. This threshold must be met and remain above the minimum requirements for a period of at least 30 consecutive days within a 120-day period. Should a User referendum not be approved for execution within the 120-day period, it is considered expired and must be resubmitted if another vote is desired. The 120-day period starts when the transaction which includes the referendum question is appended to the blockchain. EOS tokens issued during the 120-period are counted toward the total issued amount calculation.
-### Article VII - Defines Native Unit of Value.
-The native unit of value on the EOS public blockchain shall be the EOS token as defined and created by the eosio.token smart contract.
-### Article VIII - Delineates the responsibilities of maintaining the EOS blockchain.
-Elected Block Producers who have signed the regproducer Ricardian Contract will maintain the active blockchain codebase. Further, they shall participate in the testing, review, and implementation to all modifications of existing features, all optimizations, and all upgrades: present and future. Any attempt to alter any governing document, as well as any action that may alter the current state of any tokens considered "network funds" is prohibited without prior authorization obtained through a User Referendum conducted in accordance with Article VI.
+
+### Article I - User Agreement Ratification
+
+This user agreement is considered ratified and approved for purposes of governing EOS blockchain {{chain_id}} when:
+
+* at least 15% of issued tokens are participating,
+* with at least 10% more Yes than No votes,
+* sustained for at least 30 continuous days within a 120 day period.
+
+### Article II - Distributed Jurisdiction
+
+The EOS blockchain {{chain_id}} is immutable and all records and actions are recorded forever. EOS blockchain {{chain_id}} exists in a distributed and decentralized jurisdiction and is to be governed by and construed under the rules contained herein, this duly ratified agreement.
+
+### Article III - Users
+
+A user is any person or organization of persons who maintain(s) direct or indirect ownership of an EOS account and any property connected to that EOS account as defined in Article XIX.
+
+### Article IV - User Agreement Mandatory Consent
+
+By claiming direct or indirect ownership of an EOS account or property connected to an EOS account on EOS blockchain {{chain_id}} Users consent to these terms, definitions, and agreed upon standards with full consideration between all Users. {{chain_id}} string is included in the signature of every transaction validated and included in a block and appended to the Blockchain.
+
+### Article V - Additional Registered Consent 
+
+* Users who sign regproducer agree to, and are bound by, the regproducer Ricardian contract.
+* Users who sign regarb agree to, and are bound by, the regarb Ricardian contract.
+* Users who sign regforum agree to, and are bound by, the regforum Ricardian contract.
+
+### Article VI - Amending Governing Documents
+
+The EOS User Agreement, regproducer, regarb, regforum, are considered governing documents and are to be modified only by User referendum.
+
+### Article VII - On-Chain
+
+On-chain, as herein defined, means any transaction, smart contract, or Ricardian contract which is located within a block that has been deemed irreversible and appended to the EOS blockchain {{chain_id}}.
+
+### Article VIII - User Referendum
+
+User referendum is the sole mechanism for altering governing documents and/or effecting network funds. User referendums must be submitted on-chain either in full text or as a hash of the referendum text. A User referendum is considered approved for execution when:
+
+* at least 15% of issued tokens have registered a vote for the associated referendum,
+* with at least 10% more ‘affirmative’ than ‘negative’ staked EOS tokens (i.e. 55% yes, 45% no)
+* sustained for at least 30 continuous days within a 120 day period.
+
+Should a User referendum not be approved for execution within the 120-day period, it is considered expired and must be resubmitted if another vote is desired. The 120-day period starts when the transaction which includes the referendum question is appended to the Blockchain. EOS tokens issued during the 120-period are counted toward the total issued amount calculation.
+
+### Article IX - Native Unit Of Value
+
+The native unit of value on the EOS blockchain {{chain_id}} shall be the EOS token as defined and created by the eosio.token smart contract.
+
+### Article X - Maintenance Responsibilities
+
+Elected Block Producers who have signed the regproducer Ricardian contract should maintain the active Blockchain codebase. Further, they shall participate in the testing, review, and implementation to all modifications of existing features, all optimizations, and all upgrades.
+
+Any attempt to alter any governing document, as well as any action that may alter the current state of any tokens considered "network funds" is prohibited without prior authorization obtained through a User Referendum conducted in accordance with Article VIII.
+
 All other stipulations, requirements, demands, and standards for all Block Producers who agree to regproducer shall be delineated in the regproducer agreement.
-### Article IX - Defines Network Funds.
+
+### Article XI - Network Funds
+
 Network Fund accounts are accounts that hold property which is subject to distributed ownership amongst the Users, and has no single User owner. Altering any pre-existing code that directly governs the allocation, fulfillment, or distribution of any network funds also requires User referendum.
 Network fund accounts are as follows: eosio.names, eosio.ramfee, eosio.saving
-### Article X - Formally recognizes The New York Convention of 1958 allowing foreign arbitral awards to be recognized so long as the award author is registered on-chain.
-The Convention on the Recognition and Enforcement of Foreign Arbitral Awards of June 10, 1958, shall be recognized by all Users of this blockchain {{chain_id}} where the author of any such arbitral award is duly registered on-chain {{chain_id}} via regarb Ricardian.
-### Article XI - Article XI — States that valid arbitration is binding. Submission to arbitration can occur before or after a dispute so long as parties consent. Arbitration can only occur when using {{regforum}} or {{regarb}}.
-Any on-chain provision included in any on-chain transaction, smart contract, or Ricardian Contract, involving any type of EOS based property that results in controversy between parties to such a provision, or the refusal by any party to such a provision to perform the whole or any part thereof, or any controversy arising out of any other type of on-chain agreement between parties, shall be settled by arbitration. If such a provision names or appoints an arbitrator or arbitrators registered through regforum Ricardian Contract or regarb Ricardian Contract, such method shall be followed. The application of either party to the controversy to the duly named {{regforum}} or {{regarb}} in such an on-chain provision is valid and enforceable, and {{regforum}} or {{regarb}} will act to resolve the controversy with full binding force and effect. Where agreed upon, users will submit to arbitration an existing controversy arising out of an on-chain transaction, smart contract, or Ricardian contract and will be administered by an arbitrator or arbitrators registered through regforum Ricardian Contract or regarb Ricardian Contract.
-### Article XII - Defines what is "on-chain".
-On-chain, as herein defined, means any transaction, smart contract, or Ricardian contract which is located within a block that has been deemed irreversible and appended to the EOS blockchain {{chain_id}}.
-### Article XIII - Establishes the only circumstances under which accounts or contracts may be modified by Block Producers on behalf of the user.
+
+### Article XII - Recognizing The New York Convention
+
+The Convention on the Recognition and Enforcement of Foreign Arbitral Awards of June 10, 1958, shall be recognized by all Users of this Blockchain {{chain_id}} where the author of any such arbitral award is duly registered on-chain {{chain_id}} via regarb Ricardian.
+
+###  Article XIII — Binding Of Valid Arbitration
+
+Any on-chain provision included in any on-chain transaction, smart contract, or Ricardian contract, involving any type of EOS based property that results in controversy between parties to such a provision, or the refusal by any party to such a provision to perform the whole or any part thereof, or any controversy arising out of any other type of on-chain agreement between parties, shall be settled by arbitration.
+
+If such a provision names or appoints an arbitrator or arbitrators registered through regforum Ricardian contract or regarb Ricardian contract, such method shall be followed. The application of either party to the controversy to the duly named {{regforum}} or {{regarb}} in such an on-chain provision is valid and enforceable, and {{regforum}} or {{regarb}} will act to resolve the controversy with full binding force and effect. Where agreed upon, users will submit to arbitration an existing controversy arising out of an on-chain transaction, smart contract, or Ricardian contract and will be administered by an arbitrator or arbitrators registered through regforum Ricardian contract or regarb Ricardian contract.
+
+### Article XIV - Establishes the only circumstances under which accounts or contracts may be modified by Block Producers on behalf of the user.
+
 Block Producers may never affect EOS User accounts where the owners of said account have not explicitly requested and prescribed the exact actions requested and have proven their ownership, or their authority, by way of a valid arbitral award authored by a duly registered arbitrator on-chain via regarb, to Block Producers. Block Producers may charge a fee for this service which is to be deposited into the eosio.vpay network fund to be distributed across all paid nodes.
-### Article XIV - No fiduciary.
-No User shall have a fiduciary responsibility to support the value of the EOS token. No User can authorize anyone to hold assets, borrow, speak, nor contract on behalf of EOS token holders or the blockchain {{chain_ID}} collectively. This blockchain shall have no owners, managers, or fiduciaries.
-### Article XV - Personal security is the responsibility of the User, no one else.
+
+### Article XV - No Fiduciary
+
+No User shall have a fiduciary responsibility to support the value of the EOS token. No User can authorize anyone to hold assets, borrow, speak, nor contract on behalf of EOS token holders or the Blockchain {{chain_ID}} collectively. This Blockchain shall have no owners, managers, or fiduciaries.
+
+### Article XVI - User Account Security Responsibilities
+
 All items pertaining to personal account security, including but not limited to the safekeeping of private keys, is solely the responsibility of the User to secure.
-### Article XVI - Freedom of association and contract; section on the right to create contracts between users.
-The EOS Platform User Agreement grants freedom of contract based on agreement and free choice to all Users. No part of this Agreement shall impair, interfere, or infringe upon the mutually agreed upon contracts between Users.
-### Article XVII - Inflation.
-Inflation is set at 1% per annum which is to be allocated to Block Producers for services provided to the EOS Blockchain {{chain_id}}.
-### Article XVIII - EOS Property Definition
-Any object on-chain {{chain_id}} that requires a private key in order to directly manipulate, alter, transfer, influence, or otherwise effect.
+
+### Article XVII - Freedom Of Association And Contract
+
+The EOS User Agreement grants freedom of contract based on agreement and free choice to all Users. No part of this Agreement shall impair, interfere, or infringe upon the mutually agreed upon contracts between Users.
+
+### Article XVIII - Inflation
+
+Inflation is set at 1% per annum which is to be allocated to Block Producers for services provided to the EOS blockchain {{chain_id}}.
+
+### Article XIX - EOS Property
+
+Any object on-chain {{chain_id}} that requires a private key in order to directly manipulate, alter, transfer, influence, or otherwise effect it is considered property of the associated EOS account.


### PR DESCRIPTION
A few suggestions, all open for discussion:

* Broke Article III into 2 separate Articles
* Reordered a few articles
* Updated formatting
* Unified capitalization of certain terms
* Simplified wording in some cases
* Some other minor rewordings
* More concise Article titles
* Shortened document name to EOS User Agreement and mention EOS-UA abbreviation

See also https://github.com/eosnewyork/eosuseragreement/issues/4 for more discussion on Article II